### PR TITLE
Handle missing LaTeX tools gracefully

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -190,6 +190,9 @@ class MathCog(commands.Cog):
                     stderr=PIPE,
                     check=True,
                 )
+            except FileNotFoundError as e:
+                logger.error("LaTeX tool missing: %s", e)
+                raise RuntimeError(f"Rendering tool not found: {e}") from e
             except CalledProcessError as e:
                 logger.error(
                     "LaTeX subprocess failed: %s; stdout: %s; stderr: %s",


### PR DESCRIPTION
## Summary
- catch `FileNotFoundError` in `_render_text_image`
- raise a `RuntimeError` so callers get a consistent exception

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_685674f9ea108321bc8f966bdcae4e9b