### PR TITLE
Add basic math cog tests

### DIFF
--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,0 +1,36 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from sympy.parsing.latex import parse_latex
+from cogs.math import MathCog
+
+@pytest.fixture
+def cog():
+    # Create MathCog instance without running __init__ to avoid side effects
+    return object.__new__(MathCog)
+
+def test_clean_answer_strips_boxed(cog):
+    assert MathCog._clean_answer_latex(r"\boxed{5}") == "5"
+
+
+def test_clean_answer_collapse_dollars(cog):
+    assert MathCog._clean_answer_latex(r"$$5$$") == "$5$"
+    assert MathCog._clean_answer_latex(r"$$\boxed{3}$$") == "$3$"
+
+
+def test_check_answer_correct_simple(cog):
+    expr = parse_latex("5")
+    assert MathCog._check_answer(cog, "5", expr) == (True, None)
+    assert MathCog._check_answer(cog, "$5$", expr) == (True, None)
+    assert MathCog._check_answer(cog, r"$\boxed{5}$", expr) == (True, None)
+
+
+def test_check_answer_wrong(cog):
+    expr = parse_latex("5")
+    assert MathCog._check_answer(cog, "6", expr) == (False, "wrong")
+
+
+def test_check_answer_invalid(cog):
+    expr = parse_latex("5")
+    assert MathCog._check_answer(cog, "five", expr) == (False, "invalid")
+


### PR DESCRIPTION
## Summary
- test _clean_answer_latex stripping \boxed and collapsing $$
- test _check_answer correctness for numeric answers and handling of invalid/wrong

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685676aaf1948321be5dc1a148705efb