### PR TITLE
Add Asymptote block rendering

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -242,14 +242,6 @@ class MathCog(commands.Cog):
                     stderr=PIPE,
                     check=True,
                 )
-
-                subprocess.run(
-                    ["convert", "out.png", "-trim", "+repage", "out.png"],
-                    cwd=tmpdir,
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    check=True,
-                )
             except FileNotFoundError as e:
                 logger.error("LaTeX tool missing: %s", e)
                 raise RuntimeError(f"Rendering tool not found: {e}") from e

--- a/cogs/math.py
+++ b/cogs/math.py
@@ -242,6 +242,14 @@ class MathCog(commands.Cog):
                     stderr=PIPE,
                     check=True,
                 )
+
+                subprocess.run(
+                    ["convert", "out.png", "-trim", "+repage", "out.png"],
+                    cwd=tmpdir,
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    check=True,
+                )
             except FileNotFoundError as e:
                 logger.error("LaTeX tool missing: %s", e)
                 raise RuntimeError(f"Rendering tool not found: {e}") from e


### PR DESCRIPTION
## Summary
- handle `[asy]...[/asy]` blocks in LaTeX renderer
- invoke `asy` in between pdfLaTeX runs when needed
- ensure in-line blocks get newline separation and inject `import olympiad;`
- copy bundled `olympiad.asy` to temp dir so asy can load it

## Testing
- `python -m py_compile main.py cogs/*.py`
- `python - <<'PY'
import cogs.math as m
mc = m.MathCog(None)
text = "Here is figure [asy]\nsize(1cm);draw(circle((0,0),1));[/asy]"
print('Processing...')
try:
    buf = mc._render_text_image(text)
    print('ok, bytes', len(buf.getvalue()))
except Exception as e:
    print('Error:', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6856789aac648321af4dc1af07ccaf72