### PR TITLE
Use sympy in answer checking

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional
 
 import discord
 from discord.ext import commands
-from sympy import N
+from sympy import N, sympify
 from sympy.parsing.latex import parse_latex
 
 logger = logging.getLogger(__name__)
@@ -223,10 +223,10 @@ class MathCog(commands.Cog):
             diff = abs(float(N(ue, 15)) - float(N(correct_expr, 15)))
         except Exception:
             try:
-                val = eval(ans, {"__builtins__": None}, {})
-                if not isinstance(val, (int, float)):
+                ue = sympify(ans, evaluate=True)
+                if ue.free_symbols:
                     return False, "invalid"
-                diff = abs(val - float(N(correct_expr, 15)))
+                diff = abs(float(N(ue, 15)) - float(N(correct_expr, 15)))
             except Exception:
                 return False, "invalid"
         return (True, None) if diff < 1e-6 else (False, "wrong")

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -36,3 +36,14 @@ def test_check_answer_wrong(cog):
 def test_check_answer_invalid(cog):
     expr = parse_latex("5")
     assert MathCog._check_answer(cog, "five", expr) == (False, "invalid")
+
+
+def test_check_answer_numeric_expression(cog):
+    expr = parse_latex("5")
+    assert MathCog._check_answer(cog, "2+3", expr) == (True, None)
+
+
+def test_check_answer_malicious_input(cog):
+    expr = parse_latex("5")
+    ok, err = MathCog._check_answer(cog, "__import__('os').system('echo hi')", expr)
+    assert not ok


### PR DESCRIPTION
## Summary
- accept numeric expressions with `sympy.sympify`
- add tests for numeric expressions and malicious inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68567a2f4788832199c8ab88737949f9